### PR TITLE
Index page correction

### DIFF
--- a/Contato.html
+++ b/Contato.html
@@ -12,7 +12,7 @@
 				<td> <img src="imagens-projeto-final-html/logo.png"></td>
 
 				<td align="right">
-					<a href="Index.html">Home</a>|
+					<a href="index.html">Home</a>|
 					<a href="Quem_somos.html">Quem somos</a> |
 					<a href="Contato.html">Contato</a> 
 				</td>

--- a/Quem_somos.html
+++ b/Quem_somos.html
@@ -12,7 +12,7 @@
 				<td> <img src="imagens-projeto-final-html/logo.png"></td>
 
 				<td align="right">
-					<a href="Index.html">Home</a>|
+					<a href="index.html">Home</a>|
 					<a href="Quem_somos.html">Quem somos</a> |
 					<a href="Contato.html">Contato</a> 
 				</td>


### PR DESCRIPTION
Whilst navigating to links to "contato" and "quem somos nós", the returning link to index.html was broken. To correct, changes in the anchors of these pages was necessary, altering the href from **Index.html**  to **index.html**